### PR TITLE
Incluída stdio nos cabeçalhos

### DIFF
--- a/lib/Hitachi/Hitachi.h
+++ b/lib/Hitachi/Hitachi.h
@@ -2,6 +2,7 @@
 #define HITACHI_H
 
 #include "msp430.h"
+#include <stdio.h>  // for vsprintf function (it was gerating a implicit function warning)
 #include <stdarg.h> // for variadic functions
 
 #ifdef HITACHI_USE_PORT2
@@ -21,7 +22,7 @@
 #endif // HITACHI_USE_PORT2
 
 #define RS	BIT0
-#define RW  BIT1
+#define RW	BIT1
 #define E	BIT2
 
 #define DB4 BIT4


### PR DESCRIPTION
Incluída biblioteca stdio.h nos cabeçalhos por causa de um aviso de declaração implícita da função vsprintf quando acionada a  flag Wall durante a compilação